### PR TITLE
Clipboard Fix [Disabled host-only]

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -19,38 +19,39 @@ jobs:
     needs: build-base
     strategy:
       # Will build all images even if some fail.
+      # kernel edit : chromium only now
       fail-fast: false
       matrix:
         include:
-          - name: firefox
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
+          #- name: firefox
+          #  platforms: linux/amd64,linux/arm64,linux/arm/v7
           # Temporarily disabled due to Cloudflare blocked download link
           #- name: waterfox
           #  platforms: linux/amd64
           - name: chromium
             platforms: linux/amd64,linux/arm64,linux/arm/v7
-          - name: google-chrome
-            platforms: linux/amd64
-          - name: ungoogled-chromium
-            platforms: linux/amd64
-          - name: microsoft-edge
-            platforms: linux/amd64
-          - name: brave
-            platforms: linux/amd64,linux/arm64
-          - name: vivaldi
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
-          - name: opera
-            platforms: linux/amd64
-          - name: tor-browser
-            platforms: linux/amd64
-          - name: remmina
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
-          - name: vlc
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
-          - name: xfce
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
-          - name: kde
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
+          #- name: google-chrome
+          #  platforms: linux/amd64
+          #- name: ungoogled-chromium
+          #  platforms: linux/amd64
+          #- name: microsoft-edge
+          #  platforms: linux/amd64
+          #- name: brave
+          #  platforms: linux/amd64,linux/arm64
+          #- name: vivaldi
+          #  platforms: linux/amd64,linux/arm64,linux/arm/v7
+          #- name: opera
+          #  platforms: linux/amd64
+          #- name: tor-browser
+          #  platforms: linux/amd64
+          #- name: remmina
+          #  platforms: linux/amd64,linux/arm64,linux/arm/v7
+          #- name: vlc
+          #  platforms: linux/amd64,linux/arm64,linux/arm/v7
+          #- name: xfce
+          #  platforms: linux/amd64,linux/arm64,linux/arm/v7
+          #- name: kde
+          #  platforms: linux/amd64,linux/arm64,linux/arm/v7
     with:
       name: ${{ matrix.name }}
       platforms: ${{ matrix.platforms }}

--- a/.github/workflows/ghcr_intel.yml.bak
+++ b/.github/workflows/ghcr_intel.yml.bak
@@ -1,4 +1,4 @@
-name: Build and Push to GHCR for Nvidia
+name: Build and Push to GHCR for Intel
 
 on:
   push:
@@ -10,9 +10,9 @@ jobs:
     name: Base Image
     uses: ./.github/workflows/image_base.yml
     with:
-      flavor: nvidia
+      flavor: intel
       platforms: linux/amd64
-      dockerfile: Dockerfile.nvidia
+      dockerfile: Dockerfile.intel
     secrets: inherit
 
   build-app:
@@ -24,19 +24,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: firefox
-            dockerfile: Dockerfile.nvidia
-          - name: brave
-            dockerfile: Dockerfile.nvidia
+          #- name: firefox
+          # Temporarily disabled due to Cloudflare blocked download link
+          #- name: waterfox
           - name: chromium
-            dockerfile: Dockerfile.nvidia
-          - name: google-chrome
-            dockerfile: Dockerfile.nvidia
-          - name: microsoft-edge
-            dockerfile: Dockerfile.nvidia
+          #- name: google-chrome
+          #- name: ungoogled-chromium
+          #- name: microsoft-edge
+          #- name: brave
+          #- name: vivaldi
+          #- name: opera
+          #- name: tor-browser
+          #- name: remmina
+          #- name: vlc
+          #- name: xfce
+          #- name: kde
     with:
       name: ${{ matrix.name }}
-      flavor: nvidia
+      flavor: intel
       platforms: ${{ matrix.platforms }}
       dockerfile: ${{ matrix.dockerfile }}
     secrets: inherit

--- a/.github/workflows/ghcr_nvidia.yml.bak
+++ b/.github/workflows/ghcr_nvidia.yml.bak
@@ -1,4 +1,4 @@
-name: Build and Push to GHCR for Intel
+name: Build and Push to GHCR for Nvidia
 
 on:
   push:
@@ -10,9 +10,9 @@ jobs:
     name: Base Image
     uses: ./.github/workflows/image_base.yml
     with:
-      flavor: intel
+      flavor: nvidia
       platforms: linux/amd64
-      dockerfile: Dockerfile.intel
+      dockerfile: Dockerfile.nvidia
     secrets: inherit
 
   build-app:
@@ -24,24 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: firefox
-          # Temporarily disabled due to Cloudflare blocked download link
-          #- name: waterfox
+          #- name: firefox
+          #  dockerfile: Dockerfile.nvidia
+          #- name: brave
+          #  dockerfile: Dockerfile.nvidia
           - name: chromium
-          - name: google-chrome
-          - name: ungoogled-chromium
-          - name: microsoft-edge
-          - name: brave
-          - name: vivaldi
-          - name: opera
-          - name: tor-browser
-          - name: remmina
-          - name: vlc
-          - name: xfce
-          - name: kde
+            dockerfile: Dockerfile.nvidia
+          #- name: google-chrome
+          #  dockerfile: Dockerfile.nvidia
+          #- name: microsoft-edge
+          #  dockerfile: Dockerfile.nvidia
     with:
       name: ${{ matrix.name }}
-      flavor: intel
+      flavor: nvidia
       platforms: ${{ matrix.platforms }}
       dockerfile: ${{ matrix.dockerfile }}
     secrets: inherit

--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -61,7 +61,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha,format=long
 
-      - name: Log in to the Container registry
+      - name: Log in to the Container registry # needs GHCR_ACCESS_TOKEN in repo
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/server/internal/api/room/control.go
+++ b/server/internal/api/room/control.go
@@ -61,9 +61,9 @@ func (h *RoomHandler) controlRequest(w http.ResponseWriter, r *http.Request) err
 
 func (h *RoomHandler) controlRelease(w http.ResponseWriter, r *http.Request) error {
 	session, _ := auth.GetSession(r)
-	if !session.IsHost() {
-		return utils.HttpUnprocessableEntity("session is not the host")
-	}
+	// if !session.IsHost() {
+	// 	return utils.HttpUnprocessableEntity("session is not the host")
+	// }
 
 	h.desktop.ResetKeys()
 	session.ClearHost()

--- a/server/internal/config/session.go
+++ b/server/internal/config/session.go
@@ -75,7 +75,7 @@ func (Session) Init(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.PersistentFlags().Int("session.heartbeat_interval", 120, "interval in seconds for sending heartbeat messages")
+	cmd.PersistentFlags().Int("session.heartbeat_interval", 10, "interval in seconds for sending heartbeat messages")
 	if err := viper.BindPFlag("session.heartbeat_interval", cmd.PersistentFlags().Lookup("session.heartbeat_interval")); err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (Session) InitV2(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.PersistentFlags().Int("heartbeat_interval", 120, "V2: heartbeat interval in seconds")
+	cmd.PersistentFlags().Int("heartbeat_interval", 10, "V2: heartbeat interval in seconds")
 	if err := viper.BindPFlag("heartbeat_interval", cmd.PersistentFlags().Lookup("heartbeat_interval")); err != nil {
 		return err
 	}

--- a/server/internal/websocket/handler/clipboard.go
+++ b/server/internal/websocket/handler/clipboard.go
@@ -1,20 +1,22 @@
 package handler
 
 import (
-	"errors"
+	// "errors"
 
 	"github.com/m1k1o/neko/server/pkg/types"
 	"github.com/m1k1o/neko/server/pkg/types/message"
 )
 
 func (h *MessageHandlerCtx) clipboardSet(session types.Session, payload *message.ClipboardData) error {
-	if !session.Profile().CanAccessClipboard {
-		return errors.New("cannot access clipboard")
-	}
+	// Disabled: profile check
+	// if !session.Profile().CanAccessClipboard {
+	// 	return errors.New("cannot access clipboard")
+	// }
 
-	if !session.IsHost() {
-		return errors.New("is not the host")
-	}
+	// Disabled: is host check
+	// if !session.IsHost() {
+	// 	return errors.New("is not the host")
+	// }
 
 	return h.desktop.ClipboardSetText(types.ClipboardText{
 		Text: payload.Text,

--- a/server/internal/websocket/handler/control.go
+++ b/server/internal/websocket/handler/control.go
@@ -17,13 +17,15 @@ var (
 )
 
 func (h *MessageHandlerCtx) controlRelease(session types.Session) error {
-	if !session.Profile().CanHost || session.PrivateModeEnabled() {
-		return ErrIsNotAllowedToHost
-	}
+	// Disabled: profile check
+	// if !session.Profile().CanHost || session.PrivateModeEnabled() {
+	// 	return ErrIsNotAllowedToHost
+	// }
 
-	if !session.IsHost() {
-		return ErrIsNotTheHost
-	}
+	// Disabled: is host check
+	// if !session.IsHost() {
+	// 	return ErrIsNotTheHost
+	// }
 
 	h.desktop.ResetKeys()
 	session.ClearHost()

--- a/server/internal/websocket/handler/handler.go
+++ b/server/internal/websocket/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"time"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -38,7 +39,9 @@ func (h *MessageHandlerCtx) Message(session types.Session, data types.WebSocketM
 	switch data.Event {
 	// Client Events
 	case event.CLIENT_HEARTBEAT:
-		// do nothing
+		err = session.Send("system/heartbeat", map[string]any{
+			"timestamp": time.Now(),
+		})
 
 	// System Events
 	case event.SYSTEM_LOGS:

--- a/server/internal/websocket/handler/handler.go
+++ b/server/internal/websocket/handler/handler.go
@@ -39,7 +39,7 @@ func (h *MessageHandlerCtx) Message(session types.Session, data types.WebSocketM
 	switch data.Event {
 	// Client Events
 	case event.CLIENT_HEARTBEAT:
-		err = session.Send("system/heartbeat", map[string]any{
+		session.Send("system/heartbeat", map[string]any{
 			"timestamp": time.Now(),
 		})
 

--- a/server/internal/websocket/handler/keyboard.go
+++ b/server/internal/websocket/handler/keyboard.go
@@ -1,24 +1,26 @@
 package handler
 
 import (
-	"errors"
+	// "errors"
 
 	"github.com/m1k1o/neko/server/pkg/types"
 	"github.com/m1k1o/neko/server/pkg/types/message"
 )
 
 func (h *MessageHandlerCtx) keyboardMap(session types.Session, payload *message.KeyboardMap) error {
-	if !session.IsHost() {
-		return errors.New("is not the host")
-	}
+	// Disabled: is host check
+	// if !session.IsHost() {
+	// 	return errors.New("is not the host")
+	// }
 
 	return h.desktop.SetKeyboardMap(payload.KeyboardMap)
 }
 
 func (h *MessageHandlerCtx) keyboardModifiers(session types.Session, payload *message.KeyboardModifiers) error {
-	if !session.IsHost() {
-		return errors.New("is not the host")
-	}
+	// Disabled: is host check
+	// if !session.IsHost() {
+	// 	return errors.New("is not the host")
+	// }
 
 	h.desktop.SetKeyboardModifiers(payload.KeyboardModifiers)
 	return nil


### PR DESCRIPTION
Notes : 

- Disabled different build workflows, kept base & chromium only
- Build notes
  - Enable GH actions , set GHCR_ACCESS_TOKEN in Repository secrets
  - Trigger neko base & chromium build
    - i.e. `git tag v3.0.6-kernelsuffix && git push origin v3.0.6-kernelsuffix`
  - After workflows complete, set the released packages as public (to use the `ghcr.io/` url in `Dockerfile` in `onkernel/kernel-images`)

---

<span data-mesa-description="start"></span>
## TL;DR
Disabled host-only restrictions for clipboard and keyboard control functionalities, allowing all session participants to perform these actions, and streamlined GitHub Actions workflows to only build `base` and `chromium` images.

## Why we made these changes
To resolve a clipboard issue and provide more flexible control over room interactions by removing restrictive host-only checks for clipboard and keyboard operations. Build workflows were streamlined to focus on essential `base` and `chromium` images, reducing complexity and build times.

## What changed?
- **Core Functionality**: Disabled host permission checks in `server/internal/api/room/control.go`, `server/internal/websocket/handler/clipboard.go`, `server/internal/websocket/handler/control.go`, and `server/internal/websocket/handler/keyboard.go`, allowing non-host sessions to release control, set clipboard content, and configure keyboard mappings.
- **Build Workflows**: Commented out and effectively disabled builds for various browser and application images in `.github/workflows/ghcr.yml`, `.github/workflows/ghcr_intel.yml.bak`, and `.github/workflows/ghcr_nvidia.yml.bak`, focusing GHCR builds exclusively on `chromium`.
- **Documentation**: Added a comment to `.github/workflows/image_base.yml` clarifying the `GHCR_ACCESS_TOKEN` requirement.

## Validation
- [ ] Verify that non-host sessions can now successfully set clipboard content.
- [ ] Confirm that non-host sessions can configure keyboard mappings and modifiers.
- [ ] Check that `controlRelease` can be executed by non-host sessions.
- [ ] Ensure that only `base` and `chromium` images are built by the updated GitHub Actions workflows.
<span data-mesa-description="end"></span>