### PR TITLE
Keepalive fix cleanup [neko]

### DIFF
--- a/server/internal/http/legacy/event/events.go
+++ b/server/internal/http/legacy/event/events.go
@@ -4,6 +4,8 @@ const (
 	SYSTEM_INIT       = "system/init"
 	SYSTEM_DISCONNECT = "system/disconnect"
 	SYSTEM_ERROR      = "system/error"
+	SYSTEM_HEARTBEAT  = "system/heartbeat"
+	SYSTEM_PONG       = "system/pong"
 )
 
 const (

--- a/server/internal/http/legacy/message/messages.go
+++ b/server/internal/http/legacy/message/messages.go
@@ -24,6 +24,11 @@ type SystemMessage struct {
 	Message string `json:"message"`
 }
 
+type SystemPong struct {
+	Event     string `json:"event"`
+	Timestamp string `json:"timestamp"`
+}
+
 type SignalProvide struct {
 	Event string             `json:"event"`
 	ID    string             `json:"id"`

--- a/server/internal/http/legacy/wstobackend.go
+++ b/server/internal/http/legacy/wstobackend.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
+	"strconv"
+	"time"
+	
 	"github.com/pion/webrtc/v3"
 
 	oldEvent "github.com/m1k1o/neko/server/internal/http/legacy/event"
@@ -28,8 +30,10 @@ func (s *session) wsToBackend(msg []byte) error {
 	switch header.Event {
 	// Client Events
 	case oldEvent.CLIENT_HEARTBEAT:
-		// do nothing
-		return nil
+		return s.toClient(&oldMessage.SystemPong{
+			Event:     oldEvent.SYSTEM_PONG,
+			Timestamp: strconv.FormatInt(time.Now().UnixMilli(), 10),
+		})
 
 	// Signal Events
 	case oldEvent.SIGNAL_OFFER:

--- a/server/internal/websocket/handler/handler.go
+++ b/server/internal/websocket/handler/handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"time"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -39,9 +38,7 @@ func (h *MessageHandlerCtx) Message(session types.Session, data types.WebSocketM
 	switch data.Event {
 	// Client Events
 	case event.CLIENT_HEARTBEAT:
-		session.Send("system/heartbeat", map[string]any{
-			"timestamp": time.Now(),
-		})
+		err = h.systemPong(session)
 
 	// System Events
 	case event.SYSTEM_LOGS:
@@ -196,6 +193,7 @@ func (h *MessageHandlerCtx) Message(session types.Session, data types.WebSocketM
 			return h.sendBroadcast(session, payload)
 		})
 	default:
+		err = h.systemPong(session)
 		return false
 	}
 

--- a/server/internal/websocket/handler/system.go
+++ b/server/internal/websocket/handler/system.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"time"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -92,5 +93,15 @@ func (h *MessageHandlerCtx) systemLogs(session types.Session, payload *message.S
 			Msg(msg.Message)
 	}
 
+	return nil
+}
+
+func (h *MessageHandlerCtx) systemPong(session types.Session) error {
+	session.Send(
+		event.SYSTEM_PONG,
+		message.SystemPong{
+			Timestamp: time.Now().UnixMilli(),
+		},
+	)
 	return nil
 }

--- a/server/internal/websocket/manager.go
+++ b/server/internal/websocket/manager.go
@@ -32,8 +32,8 @@ var nologEvents = []string{
 	// don't log twice
 	event.SYSTEM_LOGS,
 	// don't log heartbeats
-	event.SYSTEM_HEARTBEAT,
-	event.CLIENT_HEARTBEAT,
+	// event.CLIENT_HEARTBEAT,
+	// event.SYSTEM_PONG,
 	// don't log every cursor update
 	event.SESSION_CURSORS,
 }

--- a/server/pkg/types/event/events.go
+++ b/server/pkg/types/event/events.go
@@ -7,6 +7,7 @@ const (
 	SYSTEM_LOGS       = "system/logs"
 	SYSTEM_DISCONNECT = "system/disconnect"
 	SYSTEM_HEARTBEAT  = "system/heartbeat"
+	SYSTEM_PONG       = "system/pong"
 )
 
 const (

--- a/server/pkg/types/message/messages.go
+++ b/server/pkg/types/message/messages.go
@@ -47,6 +47,11 @@ type SystemSettingsUpdate struct {
 	types.Settings
 }
 
+// SystemPong is sent by the server as a direct response to CLIENT_HEARTBEAT
+type SystemPong struct {
+	Timestamp int64 `json:"timestamp"` // Unix ms
+}
+
 /////////////////////////////
 // Signal
 /////////////////////////////


### PR DESCRIPTION
- Websocket event `system/pong` works with client live view heartbeat now ✅ 

# Next Steps :
- [`onkernel/neko`](https://github.com/onkernel/neko/)
  - Merge PR (`Keepalive fix cleanup [neko]`)
  - Release tag `v3.0.6-v1.0.1`
- [`onkernel/kernel-images`](https://github.com/onkernel/kernel-images/)
  - Merge PR (`Keepalive fix cleanup [kernel-images]`). Notes :
    - `Dockerfile` already set to _ghcr.io/**onkernel**/neko/base:3.0.6-v1.0.1_
    - after `onkernel/neko:v3.0.6-v1.0.1` tag release and build completion, would work directly

[ @Sayan- @rgarcia ]